### PR TITLE
修复 vless encryption

### DIFF
--- a/nodep/share.go
+++ b/nodep/share.go
@@ -280,6 +280,13 @@ func (proxy xrayShareLink) vlessOutbound() (*XrayOutbound, error) {
 		user.Flow = flow
 	}
 
+	encryption := query.Get("encryption")
+	if len(flow) > 0 {
+		user.Encryption = encryption
+	} else {
+		user.Encryption = "none"
+	}
+
 	var vnext XrayVLESSVnext
 	vnext.Address = proxy.link.Hostname()
 	port, err := strconv.Atoi(proxy.link.Port())

--- a/nodep/share.go
+++ b/nodep/share.go
@@ -281,7 +281,7 @@ func (proxy xrayShareLink) vlessOutbound() (*XrayOutbound, error) {
 	}
 
 	encryption := query.Get("encryption")
-	if len(flow) > 0 {
+	if len(encryption) > 0 {
 		user.Encryption = encryption
 	} else {
 		user.Encryption = "none"

--- a/nodep/xray_json.go
+++ b/nodep/xray_json.go
@@ -63,8 +63,9 @@ type XrayVLESSVnext struct {
 }
 
 type XrayVLESSVnextUser struct {
-	Id   string `json:"id,omitempty"`
-	Flow string `json:"flow,omitempty"`
+	Id         string `json:"id,omitempty"`
+	Flow       string `json:"flow,omitempty"`
+	Encryption string `json:"encryption,omitempty"`
 }
 
 type XrayVMess struct {


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/discussions/716  
4.2.2 (VMess/VLESS) encryption

当协议为 VLESS 时，对应配置文件出站中 settings.encryption，当前可选值只有 none。

省略时默认为 none，但不可以为空字符串。