### PR TITLE
Add Log Handler

### DIFF
--- a/log/android.go
+++ b/log/android.go
@@ -1,0 +1,49 @@
+//go:build android
+
+package log
+
+/*
+#cgo LDFLAGS: -landroid -llog
+
+#include <android/log.h>
+#include <string.h>
+#include <stdlib.h>
+*/
+import "C"
+import "unsafe"
+
+import (
+	"github.com/xtls/xray-core/common/log"
+)
+
+var ctag = C.CString("xray")
+
+type AndroidLogger struct {
+}
+
+func (al *AndroidLogger) Handle(msg log.Message) {
+	message := msg.String()
+	var priority = C.ANDROID_LOG_FATAL // this value should never be used in client mode
+	generalMsg, ok := msg.(*log.GeneralMessage)
+	if ok {
+		switch generalMsg.Severity {
+		case log.Severity_Error:
+			priority = C.ANDROID_LOG_ERROR
+		case log.Severity_Warning:
+			priority = C.ANDROID_LOG_WARN
+		case log.Severity_Info:
+			priority = C.ANDROID_LOG_INFO
+		case log.Severity_Debug:
+			priority = C.ANDROID_LOG_DEBUG
+		}
+	}
+	cstr := C.CString(message)
+	defer C.free(unsafe.Pointer(cstr))
+	C.__android_log_write(C.int(priority), ctag, cstr)
+}
+
+func init() {
+	common.Must(xlog.RegisterHandlerCreator(xlog.LogType_Console, func(_ xlog.LogType, _ xlog.HandlerCreatorOptions) (log.Handler, error) {
+		return &AndroidLogger{}, nil
+	}))
+}

--- a/log/ios.go
+++ b/log/ios.go
@@ -1,0 +1,61 @@
+//go:build ios
+
+package log
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation
+
+#include <os/log.h>
+#include <stdlib.h>
+#include <string.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+static os_log_t logger = NULL;
+
+void OSLog(uint8_t type, const char *message) {
+    if (logger == NULL) {
+        logger = os_log_create("cc.cross.Mango", "xray");
+    }
+    os_log_with_type(logger, type, "%{public}s", message);
+}
+*/
+import "C"
+
+import (
+	xlog "github.com/xtls/xray-core/app/log"
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/log"
+	"unsafe"
+)
+
+var logger = C.os_log_create(C.CString("io.github.xtls"), C.CString("xray"))
+
+type iOSLogger struct {
+}
+
+func (l *iOSLogger) Handle(msg log.Message) {
+	message := msg.String()
+	var logType uint8 = 0x00
+	generalMsg, ok := msg.(*log.GeneralMessage)
+	if ok {
+		switch generalMsg.Severity {
+		case log.Severity_Error:
+			logType = 0x10
+		case log.Severity_Warning:
+			logType = 0x01
+		case log.Severity_Info:
+			logType = 0x01
+		case log.Severity_Debug:
+			logType = 0x02
+		}
+	}
+	cstr := C.CString(message)
+	defer C.free(unsafe.Pointer(cstr))
+	C.OSLog(C.uint8_t(logType), cstr)
+}
+
+func init() {
+	common.Must(xlog.RegisterHandlerCreator(xlog.LogType_Console, func(_ xlog.LogType, _ xlog.HandlerCreatorOptions) (log.Handler, error) {
+		return &iOSLogger{}, nil
+	}))
+}

--- a/log/ios.go
+++ b/log/ios.go
@@ -14,7 +14,7 @@ static os_log_t logger = NULL;
 
 void OSLog(uint8_t type, const char *message) {
     if (logger == NULL) {
-        logger = os_log_create("cc.cross.Mango", "xray");
+        logger = os_log_create("io.github.xtls", "xray");
     }
     os_log_with_type(logger, type, "%{public}s", message);
 }
@@ -27,8 +27,6 @@ import (
 	"github.com/xtls/xray-core/common/log"
 	"unsafe"
 )
-
-var logger = C.os_log_create(C.CString("io.github.xtls"), C.CString("xray"))
 
 type iOSLogger struct {
 }

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,7 @@
+//go:build !ios && !android
+
+package log
+
+func init() {
+
+}

--- a/xray_wrapper.go
+++ b/xray_wrapper.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
+	_ "github.com/xtls/libxray/log"
 	"github.com/xtls/libxray/nodep"
 	"github.com/xtls/libxray/xray"
 )


### PR DESCRIPTION
add log handler to make it easier to see logs on iOS and Android and configure the logs to be switched on and off by the config.
