### PR TITLE
Added a new api `NewXrayRequest`

### DIFF
--- a/xray_wrapper.go
+++ b/xray_wrapper.go
@@ -138,6 +138,21 @@ type RunXrayRequest struct {
 	ConfigPath string `json:"configPath,omitempty"`
 }
 
+// Create Xray Run Request
+func NewXrayRunRequest(datDir, configPath string) (string, error) {
+	request := RunXrayRequest{
+		DatDir:     datDir,
+		ConfigPath: configPath,
+	}
+	requestBytes, err := json.Marshal(request)
+	if err != nil {
+		return "", err
+	}
+
+	// Encode the JSON bytes to a base64 string
+	return base64.StdEncoding.EncodeToString(requestBytes), nil
+}
+
 // Run Xray instance.
 func RunXray(base64Text string) string {
 	var response nodep.CallResponse[string]


### PR DESCRIPTION
Added a new api `NewXrayRequest` which will allow us to create a base64 encoded request from given dat file dir and config path in the function argument. I think it's a better a more formal way to create a Xray Run Request which is straight forward. But before it was little annoying to me as I need to first create a Xray request pass paths my self then encode it myslelf then pass to Run funciton etc blah blah alot of work to me. So this function does all of that with a single call which I feel is useful. Also it returns (similarly in the test it uses) an error if something broke in between. If you have any other questions about the implementation reply to this thread. Thank you