### PR TITLE
Changed it to min api 21

### DIFF
--- a/build/app/android.py
+++ b/build/app/android.py
@@ -16,7 +16,7 @@ class AndroidBuilder(Builder):
         self.clean_lib_files(clean_files)
         os.chdir(self.lib_dir)
         ret = subprocess.run(
-            ["gomobile", "bind", "-target", "android", "-androidapi", "28"]
+            ["gomobile", "bind", "-target", "android", "-androidapi", "21"]
         )
         if ret.returncode != 0:
             raise Exception("build failed")


### PR DESCRIPTION
Changed it to min api 21 cause you see there are alot of devices which runs xray and are less than api level 28. So if you set it to 28 then alot of devices gets cutt of  support like few days ago I faced the same issue when I tried to build libXray and setup in android project it just don't work on devices below api level 28 so made it 21 so it works on android 5.0 and up devices. For reference v2rayNG also uses same api level for xray wrapper which is 21