### PR TITLE
Added 16kb page size

### DIFF
--- a/build/app/android.py
+++ b/build/app/android.py
@@ -15,8 +15,11 @@ class AndroidBuilder(Builder):
         clean_files = ["libXray-sources.jar", "libXray.aar"]
         self.clean_lib_files(clean_files)
         os.chdir(self.lib_dir)
+        env = os.environ.copy()
+        env["CGO_LDFLAGS"] = "-O2 -g -s -w -Wl,-z,max-page-size=16384"
         ret = subprocess.run(
-            ["gomobile", "bind", "-target", "android", "-androidapi", "28"]
+            ["gomobile", "bind", "-target", "android", "-androidapi", "21"],
+            env=env
         )
         if ret.returncode != 0:
             raise Exception("build failed")


### PR DESCRIPTION
In the android build script I have added support for 16kb page sizes as google requires after android 15. Here is the docs link : https://developer.android.com/guide/practices/page-sizes
And I found the solution for go mobile from this github issue thread : https://github.com/ProtonMail/gopenpgp/issues/300

The guy named 250King's solution woks and implemented that one. Thank you