### PR TITLE
DNS : Create a new api for dns request

### DIFF
--- a/dns_wrapper.go
+++ b/dns_wrapper.go
@@ -15,6 +15,21 @@ type InitDnsRequest struct {
 	DeviceName string `json:"deviceName,omitempty"`
 }
 
+// Init Dns Request
+func NewInitDnsRequest(dns, deviceName string) (string, error) {
+	request := InitDnsRequest{
+		Dns:        dns,
+		DeviceName: deviceName,
+	}
+
+	requestBytes, err := json.Marshal(request)
+	if err != nil {
+		return "", err
+	}
+	// Encode the JSON bytes to a base64 string
+	return base64.StdEncoding.EncodeToString(requestBytes), nil
+}
+
 // Init Dns.
 func InitDns(base64Text string) string {
 	var response nodep.CallResponse[string]


### PR DESCRIPTION
So created a dns request function which takes in the arguments and returns base64Text and a error (if like occurs) . It make it easy to work with `InitDns` and the api looks like this `func NewInitDnsRequest(dns, deviceName string) (string, error)` which takes the same parameters as the struct