### PR TITLE
cgo_bridge: export CGoSetEnv so hosts can reach xray-core env knobs

### DIFF
--- a/cgo_bridge/main.go
+++ b/cgo_bridge/main.go
@@ -6,6 +6,7 @@ package main
 import "C"
 
 import (
+	"os"
 	"unsafe"
 
 	libXray "github.com/xtls/libxray"
@@ -22,4 +23,23 @@ func CGoInvoke(requestJSON *C.char) *C.char {
 //export CGoFree
 func CGoFree(value *C.char) {
 	C.free(unsafe.Pointer(value))
+}
+
+// CGoSetEnv sets an environment variable inside the Go runtime.
+//
+// The Go runtime snapshots environ when the c-archive image initializes, so a
+// libc setenv() performed later by the host application is never visible to
+// os.LookupEnv. That makes xray-core's env-based knobs unreachable from a
+// non-Go host — most importantly platform.TunFdKey ("xray.tun.fd"), which
+// proxy/tun/tun_darwin.go reads to adopt an existing tun descriptor.
+//
+// On iOS the descriptor only exists after NEPacketTunnelProvider.startTunnel,
+// long after the snapshot, so the "iOS: use provided fd from NetworkExtension"
+// branch can never be taken: NewTun falls through to creating its own utun via
+// an AF_SYSTEM socket, which the app sandbox denies, and the inbound fails with
+// "app/proxyman/inbound: failed to start proxy > operation not permitted".
+//
+//export CGoSetEnv
+func CGoSetEnv(name *C.char, value *C.char) {
+	_ = os.Setenv(C.GoString(name), C.GoString(value))
 }


### PR DESCRIPTION
## Problem

The Go runtime snapshots `environ` when a c-archive image initializes. A
`setenv()` performed later by the host application is therefore never visible
to `os.LookupEnv`, which is what `common/platform.EnvFlag` uses.

That makes every env-based knob in xray-core unreachable from a non-Go host.
The one that matters in practice is `platform.TunFdKey` (`xray.tun.fd`), read
by `proxy/tun/tun_darwin.go` in the branch commented "iOS: use provided fd from
NetworkExtension".

On iOS the tun descriptor only exists after
`NEPacketTunnelProvider.startTunnel` runs — long after the snapshot — so a
Swift host cannot publish it. `NewTun` then falls through to the macOS path and
tries to create its own utun via an `AF_SYSTEM` socket, which the app sandbox
denies:

```
app/proxyman/inbound: failed to start proxy > operation not permitted
```

Reproduced on iPhone 16 Pro / iOS 26.6 with libXray v26.7.28, and isolated with
a minimal spike: a C program calls `setenv("xray.tun.fd", "5", 1)` and then an
exported Go function — `getenv` returns `5`, `os.LookupEnv` returns
`found=false`.

## Change

One exported function in `cgo_bridge`, calling `os.Setenv` inside the Go
runtime. No behavior change for existing callers; nothing else is touched.

With it, the iOS branch of `NewTun` finally becomes reachable: our client now
brings the tunnel up on device with the same core version that previously
failed at the inbound. The packet path needed no further work — the 4-byte utun
header is handled in `DarwinTun.ReadPacket`/`WritePacket`, which are shared with
the macOS path.

## Alternative considered

Passing the descriptor through `TunConfig` (a `fd` field) would be more
explicit and would not rely on process env at all. That is a larger change to
xray-core's config surface; happy to prepare it instead if maintainers prefer.
