### PR TITLE
Validate Xray configurations through instance construction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,22 @@ python3 build/main.py apple go
 
 Other targets and local-core options are documented in [build usage](README.md#usage).
 
-## Pull requests
+## Agent skills
 
-Use English for PR titles and descriptions. Keep titles, descriptions, and
-comments self-contained: do not mention or link to another repository's PR,
-including companion, dependency, or merge-order references. Describe required
-interface or build behavior directly.
+### Issue tracker
+
+GitHub Issues for `XTLS/libXray`. Before issue or PR work, read
+[issue tracker](docs/agents/issue-tracker.md).
+
+### Triage labels
+
+Use the five canonical triage labels. Before triage, read
+[label mapping](docs/agents/triage-labels.md).
+
+### Domain docs
+
+Single-context layout. Before codebase exploration or domain/ADR work,
+read [domain guidance](docs/agents/domain.md).
 
 ## Verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,10 @@ and the models/dispatch in `invoke_model.go` and `invoke.go`.
 - Applications use `Invoke`/`CGoInvoke` with typed requests. Config methods receive
   `xrayJson` text, not configuration file paths. Runtime `env` belongs inside
   that Xray JSON. File-oriented APIs and the desktop Core CLI retain file access.
-- `TestXray` only loads/builds configuration with `core.LoadConfig`; it neither
-  constructs nor starts an instance. Success does not guarantee startup or
-  connectivity. Builders may still read local assets/certificates and apply `env`.
+- `TestXray` constructs an instance through `newXrayInstance` and closes it
+  without calling `Start`. Callers own minimal/filtered validation configs.
+  Process-level side effects are accepted; startup resources and connectivity
+  remain outside this check. See [testXray](README.md#testxray) for limitations.
 - Manage one running instance. Validation and temporary instances must reject
   managed-instance overlap before loading configuration and hold the lifecycle
   lock through worker completion and instance cleanup. Close temporary instances

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ failure and do not perform either request.
 
 ### testXray
 
-Loads and builds the complete configuration from the supplied JSON text. The
+Loads the supplied JSON text and constructs a temporary Xray instance. The
 payload contains only `xrayJson`; success returns `data: {}`:
 
 ```json
@@ -465,17 +465,26 @@ payload contains only `xrayJson`; success returns `data: {}`:
 }
 ```
 
-The Go entrypoint `TestXray` uses `core.LoadConfig` without constructing or
-starting an Xray instance or runtime handlers. It validates configuration
-structure, including TUN/WireGuard definitions, without creating devices,
-listeners, log files, or background connections. The builder can still read
-local GeoData/certificates and apply the root `env` to the current process.
-Geodata asset declarations validate HTTPS URLs and existing local files; their
-downloader/cron does not run during validation.
+The Go entrypoint `TestXray` calls `newXrayInstance` (`core.LoadConfig` followed
+by `core.New`) and closes the successfully constructed instance before returning.
+It never calls `Start` or publishes a managed instance. Core construction errors,
+including invalid routing matchers and missing balancers, and close errors are
+returned through the normal error response.
 
-A successful check establishes that the configuration builds. It does not
-prove that runtime resources are available, that an instance can start, or
-that the network is reachable. Callers must handle actual startup failures.
+This is not a sandbox. Builders and constructors may read local GeoData and
+certificates, apply `env`, replace process-global logging/DNS state, create log
+files, or initialize protocol-specific resources and background tasks. Process
+state is not restored. In particular, WireGuard can acquire a TUN during
+construction and VLESS reverse can schedule background work. The current Core
+does not return its partial instance when construction fails, so libXray cannot
+close that partial instance. Core-managed geodata cron does not run without
+`Start`, although its asset declarations still check local files.
+
+Callers may provide a minimal configuration or remove App-managed fields from a
+disposable validation copy; libXray applies no App-specific filtering. Only the
+supplied configuration is checked. Success establishes instance construction and
+close, not listener/TUN startup, system permissions, or network connectivity.
+Callers must handle actual startup failures.
 
 ### runXray
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,23 @@
+# Domain Docs
+
+This repository uses a single-context layout: domain terminology lives in
+`CONTEXT.md` at the repository root, and architecture decisions live in
+`docs/adr/`.
+
+## Reading rules
+
+- Before exploring the codebase, read the root `CONTEXT.md` when it exists.
+- Before changing an implementation, read ADRs under `docs/adr/` that affect
+  the area being changed.
+- If these files do not exist, proceed silently without creating setup
+  placeholders. The `/domain-modeling` skill creates them when terminology
+  or decisions actually need recording.
+
+## Vocabulary and decisions
+
+- Use terms defined in `CONTEXT.md`; avoid synonyms the glossary explicitly
+  rejects.
+- If a needed concept is missing, first check whether it is existing project
+  terminology. Leave genuine gaps for `/domain-modeling` to resolve.
+- When a proposal contradicts an existing ADR, explicitly identify the
+  conflict and the reasoning instead of silently overriding the decision.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,50 @@
+# Issue tracker: GitHub
+
+Issues and specs live in GitHub Issues for `XTLS/libXray`.
+
+Use the `gh` CLI. Because this clone's `origin` uses `yiguo.dev`,
+include `--repo XTLS/libXray` in every `gh issue` and `gh pr` command.
+For `gh api`, use explicit `repos/XTLS/libXray/...` endpoints.
+
+## Conventions
+
+- Use English for issue and PR titles, descriptions, and GitHub comments.
+- Keep PR titles, descriptions, and comments self-contained. Do not mention
+  or link to another repository's PR, including companion, dependency, or
+  merge-order references. Describe required interface or build behavior directly.
+- Use [triage-labels.md](triage-labels.md) for canonical triage roles.
+- Use a heredoc for multiline bodies.
+
+## Issue operations
+
+- Publish a ticket: `gh issue create --repo XTLS/libXray --title "..." --body "..."`
+- Fetch a ticket: `gh issue view <number> --repo XTLS/libXray --comments`
+- List tickets: `gh issue list --repo XTLS/libXray --state open --json number,title,body,labels,comments`
+- Comment: `gh issue comment <number> --repo XTLS/libXray --body "..."`
+- Add or remove labels: `gh issue edit <number> --repo XTLS/libXray --add-label "..."` or `--remove-label "..."`
+- Close: `gh issue close <number> --repo XTLS/libXray --comment "..."`
+
+GitHub shares one number space across issues and PRs. Resolve an ambiguous
+number with `gh pr view <number> --repo XTLS/libXray`, falling back to
+`gh issue view <number> --repo XTLS/libXray`.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.**
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The map is one issue with child issues as tickets.
+
+- Map: label it `wayfinder:map`.
+- Child ticket: link it as a GitHub sub-issue. If unavailable, add it to the
+  map's task list and put `Part of #<map>` at the top of the child body.
+- Child labels: `wayfinder:research`, `wayfinder:prototype`,
+  `wayfinder:grilling`, or `wayfinder:task`.
+- Blocking: use GitHub issue dependencies. If unavailable, put
+  `Blocked by: #<n>` at the top of the child body.
+- Frontier: choose the first open, unassigned child in map order without
+  an open blocker.
+- Claim: `gh issue edit <number> --repo XTLS/libXray --add-assignee @me`
+- Resolve: comment with the answer, close the child, then add a context
+  pointer to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,11 @@
+# Triage Labels
+
+| Canonical role | GitHub label | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Waiting for maintainer evaluation |
+| `needs-info` | `needs-info` | Waiting for the reporter to provide more information |
+| `ready-for-agent` | `ready-for-agent` | Requirements are clear; ready for an agent |
+| `ready-for-human` | `ready-for-human` | Requires human implementation |
+| `wontfix` | `wontfix` | Not planned |
+
+When a skill mentions a canonical role, use its corresponding GitHub label.

--- a/invoke_test.go
+++ b/invoke_test.go
@@ -211,19 +211,15 @@ func TestInvokeTestXray(t *testing.T) {
 	requireNoDataObject(t, response)
 }
 
-func TestInvokeTestXrayDoesNotCreateRuntimeResources(t *testing.T) {
-	logPath := filepath.Join(t.TempDir(), "not-created", "error.log")
+func TestInvokeTestXrayConstructsWithoutStarting(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "error.log")
 	config, err := json.Marshal(map[string]any{
 		"log": map[string]any{"error": logPath, "loglevel": "debug"},
 		"inbounds": []any{
 			map[string]any{"tag": "tunIn", "protocol": "tun", "settings": map[string]any{"name": "TestXrayMustNotCreate", "mtu": 1500}},
 		},
 		"outbounds": []any{
-			map[string]any{"protocol": "wireguard", "settings": map[string]any{
-				"secretKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-				"address":   []string{"10.0.0.2/32"},
-				"peers":     []any{map[string]any{"publicKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", "endpoint": "127.0.0.1:9"}},
-			}},
+			map[string]any{"protocol": "freedom", "tag": "direct"},
 		},
 	})
 	if err != nil {
@@ -231,15 +227,26 @@ func TestInvokeTestXrayDoesNotCreateRuntimeResources(t *testing.T) {
 	}
 	response := invokeForTest(t, LibXrayMethodTestXray, TestXrayRequest{XrayJson: string(config)})
 	if !response.Success {
-		t.Fatalf("testXray must accept structurally valid TUN/WireGuard without construction: %s", response.Err)
+		t.Fatalf("testXray must construct handlers without starting the TUN: %s", response.Err)
 	}
 	requireNoDataObject(t, response)
-	if _, err := os.Stat(filepath.Dir(logPath)); !os.IsNotExist(err) {
-		t.Fatalf("testXray created a runtime log directory: %v", err)
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("testXray did not construct the configured file logger: %v", err)
 	}
 	response = invokeForTest(t, LibXrayMethodTestXray, TestXrayRequest{XrayJson: `{"outbounds":[{"protocol":"unknown"}]}`})
 	if response.Success || string(response.Data) != "null" {
 		t.Fatalf("testXray must still reject invalid core configuration: %+v", response)
+	}
+}
+
+func TestInvokeTestXrayReturnsConstructionError(t *testing.T) {
+	response := invokeForTest(t, LibXrayMethodTestXray, TestXrayRequest{XrayJson: `{
+		"log":{"loglevel":"none"},
+		"outbounds":[{"protocol":"freedom","tag":"direct"}],
+		"routing":{"rules":[{"domain":["example.com"],"balancerTag":"missing"}]}
+	}`})
+	if response.Success || string(response.Data) != "null" || !strings.Contains(response.Err, "balancer missing not found") {
+		t.Fatalf("testXray must expose the core construction error: %+v", response)
 	}
 }
 

--- a/readme/README.zh_CN.md
+++ b/readme/README.zh_CN.md
@@ -355,7 +355,7 @@ GET 成功后把响应正文原样放入 `locationJson` 字符串。JSON 解析�
 
 ### testXray
 
-加载并构建传入的完整 Xray JSON 文本。payload 仅包含 `xrayJson`，成功时返回
+加载传入的 Xray JSON 文本并构造临时 instance。payload 仅包含 `xrayJson`，成功时返回
 `data: {}`：
 
 ```json
@@ -368,13 +368,19 @@ GET 成功后把响应正文原样放入 `locationJson` 字符串。JSON 解析�
 }
 ```
 
-Go 入口 `TestXray` 只调用 `core.LoadConfig`，不构造或启动 Xray instance 及运行时
-handler。它校验包括 TUN/WireGuard 定义在内的配置结构，不创建设备、监听、日志文件
-或后台连接。构建器仍可能读取本地 GeoData/证书，并将根 `env` 应用到当前进程。
-Geodata assets 声明只校验 HTTPS URL 和已存在的本地文件，下载器及 cron 不在校验时运行。
+Go 入口 `TestXray` 调用 `newXrayInstance`（`core.LoadConfig → core.New`），成功构造后
+关闭临时 instance，再返回结果。不调用 `Start`，也不登记为受管理的运行 instance。
+路由匹配器、缺失 balancer 等构造错误以及关闭错误通过正常错误响应返回。
 
-校验成功只说明配置可以构建，不保证运行资源可用、instance 可以启动或网络可以连接。
-调用方仍须处理实际启动失败。
+校验不是沙箱：构建器和构造器可能读取本地 GeoData/证书、应用 `env`、替换进程级
+日志/DNS 状态、创建日志文件，或初始化协议专属资源与后台任务。这些进程状态不恢复。
+WireGuard 可能在构造时创建 TUN，VLESS reverse 可能安排后台任务。当前 Core 构造失败时
+不返回部分 instance，因此 libXray 无法关闭该部分 instance。不调用 `Start` 时，内核
+Geodata cron 不运行，但 assets 声明仍会检查本地文件。
+
+调用方允许构造最小配置，或在验证副本中排除 App 管理的字段；libXray 不做 App 专属裁剪。
+成功只说明传入配置可以完成实例构造和关闭，不覆盖监听/TUN 启动、系统权限与网络连通性。
+被排除的配置不在验证范围内，调用方仍须处理实际启动失败。
 
 ### runXray
 

--- a/xray/validation.go
+++ b/xray/validation.go
@@ -2,20 +2,20 @@ package xray
 
 import (
 	"errors"
-	"strings"
-
-	"github.com/xtls/xray-core/core"
 )
 
-// TestXray only builds the configuration; it does not instantiate handlers.
-// The core builder can read local assets/certificates and apply root env values.
-// Success does not guarantee that the configuration can start.
+// TestXray constructs and closes an instance without calling Start.
+// Constructors may change process state and acquire resources. Callers own any
+// configuration projection; startup resources and connectivity are not tested.
 func TestXray(xrayJSON string) error {
 	coreServerMu.Lock()
 	defer coreServerMu.Unlock()
 	if coreServer != nil {
 		return errors.New("testXray requires an isolated process without a managed Xray instance")
 	}
-	_, err := core.LoadConfig("json", strings.NewReader(xrayJSON))
-	return err
+	server, err := newXrayInstance(xrayJSON)
+	if err != nil {
+		return err
+	}
+	return server.Close()
 }

--- a/xray/validation_test.go
+++ b/xray/validation_test.go
@@ -1,0 +1,53 @@
+package xray
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/xtls/xray-core/core"
+)
+
+func TestTestXrayRejectsConstructionErrors(t *testing.T) {
+	for name, rule := range map[string]string{
+		"missing balancer": `{"domain":["example.com"],"balancerTag":"missing"}`,
+		"invalid regexp":   `{"domain":["regexp:["],"outboundTag":"direct"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := `{"log":{"loglevel":"none"},"outbounds":[{"protocol":"freedom","tag":"direct"}],"routing":{"rules":[` + rule + `]}}`
+			if _, err := core.LoadConfig("json", strings.NewReader(config)); err != nil {
+				t.Fatalf("fixture must pass the old build-only check: %v", err)
+			}
+			if err := TestXray(config); err == nil {
+				t.Fatal("construction error was accepted")
+			}
+			if GetXrayState() {
+				t.Fatal("validation published a managed instance")
+			}
+		})
+	}
+}
+
+func TestTestXrayDoesNotBindPorts(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	port := listener.Addr().(*net.TCPAddr).Port
+	config := fmt.Sprintf(`{
+		"log":{"loglevel":"none"},
+		"stats":{},"metrics":{"listen":"127.0.0.1:%d"},
+		"inbounds":[{"listen":"127.0.0.1","port":%d,"protocol":"socks"}],
+		"outbounds":[{"protocol":"freedom","tag":"direct"}]
+	}`, port, port)
+	for range 2 {
+		if err := TestXray(config); err != nil {
+			t.Fatalf("validation must not start listeners: %v", err)
+		}
+		if GetXrayState() {
+			t.Fatal("validation left a managed instance")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Change `TestXray` from configuration loading only to `newXrayInstance` followed by `Close`, without calling `Start` or publishing a managed instance.
- Return construction errors, including invalid routing matchers and missing balancers, through the existing error response.
- Retain the lifecycle lock and rejection of overlap with a managed running instance. Keep API version 3 and the existing request/response contract.
- Update the English/Chinese API documentation and repository guidance to describe the new validation boundary.

## Behavior and limitations

Callers can supply minimal configurations or filter application-managed settings in a disposable validation copy. The library does not apply application-specific filtering or restore process-global side effects. Successful validation confirms instance construction and cleanup, not listener/TUN startup, system permissions, or network connectivity.

## Validation

- `go test ./... -count=1`
- `python3 build/main.py android`
- `python3 build/main.py apple go`
- Verified that builds restored `go.mod` and `go.sum`.
- Regression coverage verifies constructor-only failures, occupied listener ports, no TUN startup, and unchanged Invoke response semantics.
- `git diff --check`

Windows/Linux artifacts and real VPN startup were not tested.
